### PR TITLE
Add missing optional paramater default value

### DIFF
--- a/pypager/source.py
+++ b/pypager/source.py
@@ -382,7 +382,7 @@ class StringSource(Source):
     Take a Python string is input for the pager.
     """
 
-    def __init__(self, text: str, lexer: Optional[Lexer], name: str = "") -> None:
+    def __init__(self, text: str, lexer: Optional[Lexer] = None, name: str = "") -> None:
         self.text = text
         self.lexer = lexer
         self.name = name


### PR DESCRIPTION
Using "Optional" (and no default value), does not make the argument optional.
See https://docs.python.org/3/library/typing.html#typing.Optional